### PR TITLE
Allow safe_get to accept list == None.

### DIFF
--- a/lib/m21utils.py
+++ b/lib/m21utils.py
@@ -350,7 +350,9 @@ def note_to_string(note):
 
 
 def safe_get(list, idx):
-    if idx < len(list) and idx >= 0:
+    if list is None:
+        out = None
+    elif idx < len(list) and idx >= 0:
         out = list[idx]
     else:
         out = None


### PR DESCRIPTION
Ran into a crash here when diffing these two MusicXML scores.  I'm honestly not sure if there's a bug somewhere causing this list to be None, but it seems like safe_get should return None in this case.  With this fix, the comparison was correct (the scores are identical).  Oh, maybe that's why the the list is None, because there are zero differences?

[two_musicxml_files.zip](https://github.com/fosfrancesco/music-score-diff/files/7071607/two_musicxml_files.zip)
