### PR TITLE
A new compare.py script for easy comparison of two score files.

### DIFF
--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,132 @@
+import json
+import sys
+import os
+import resource
+import argparse
+from pathlib import Path
+
+import music21 as m21
+import lib.score_visualization as sv
+import lib.m21utils as m21u
+import lib.NotationLinear as nlin
+import lib.score_comparison_lib as scl
+from timeit import default_timer as timer
+
+# To use the new Humdrum importer from converter21 in place of the one in music21:
+# git clone https://github.com/gregchapman-dev/converter21.git
+# pip install converter21 # or pip install -e converter21 if you want it "editable"
+# Then uncomment all lines in this file marked "# c21"
+
+# from converter21 import HumdrumConverter # c21
+
+def getInputExtensionsList() -> [str]:
+    c = m21.converter.Converter()
+    inList = c.subconvertersList('input')
+    result = []
+    for subc in inList:
+        for inputExt in subc.registerInputExtensions:
+            result.append('.' + inputExt)
+    return result
+
+def printSupportedInputFormats():
+    c = m21.converter.Converter()
+    inList = c.subconvertersList('input')
+    print("Supported input formats are:")
+    for subc in inList:
+        if subc.registerInputExtensions:
+            print('\tformats   : ' + ', '.join(subc.registerFormats)
+                    + '\textensions: ' + ', '.join(subc.registerInputExtensions))
+
+# ------------------------------------------------------------------------------
+
+'''
+    main entry point (parse arguments and do conversion)
+'''
+# to use the new Humdrum importer from converter21 in place of the one in music21...
+# m21.converter.unregisterSubconverter(m21.converter.subConverters.ConverterHumdrum) # c21
+# m21.converter.registerSubconverter(HumdrumConverter)                               # c21
+# print('registered converter21 humdrum importer')                                   # c21
+
+parser = argparse.ArgumentParser()
+parser.add_argument("file1",
+                    help="first music file to compare")
+parser.add_argument("file2",
+                    help="second music file to compare")
+
+print('music21 version:', m21.base.VERSION_STR)
+args = parser.parse_args()
+
+# check file1 and file2 extensions for support within music21
+badExt: bool = False
+_, fileExt1 = os.path.splitext(args.file1)
+_, fileExt2 = os.path.splitext(args.file2)
+
+if fileExt1 not in getInputExtensionsList():
+    print("file1 extension '{}' not supported.".format(fileExt1))
+    badExt = True
+if fileExt2 not in getInputExtensionsList():
+    print("file2 extension '{}' not supported.".format(fileExt2))
+    badExt = True
+if badExt:
+    printSupportedInputFormats()
+    sys.exit(1)
+
+#print('stack limit =', resource.getrlimit(resource.RLIMIT_STACK))
+#print('recursion limit =', sys.getrecursionlimit())
+
+#sys.setrecursionlimit(1024*1024)
+
+#print('new stack limit =', resource.getrlimit(resource.RLIMIT_STACK))
+#print('new recursion limit =', sys.getrecursionlimit())
+totalTime = 0
+start = timer()
+score1 = m21.converter.parse(args.file1, forceSource=True)
+end = timer()
+print('imported first file into music21 score: {:.3f} seconds'.format(end - start))
+totalTime += end - start
+
+start = timer()
+score2 = m21.converter.parse(args.file2, forceSource=True)
+end = timer()
+print('imported second file into music21 score: {:.3f} seconds'.format(end - start))
+totalTime += end - start
+
+# build ScoreTrees
+start = timer()
+score_lin1 = nlin.Score(score1)
+end = timer()
+print('built ScoreTree from score1: {:.3f} seconds'.format(end - start))
+totalTime += end - start
+
+start = timer()
+score_lin2 = nlin.Score(score2)
+end = timer()
+print('built ScoreTree from score2: {:.3f} seconds'.format(end - start))
+totalTime += end - start
+
+# compute the complete score diff
+start = timer()
+op_list, cost = scl.complete_scorelin_diff(score_lin1, score_lin2)
+end = timer()
+print('diffed two ScoreTrees: {:.3f} seconds'.format(end - start))
+totalTime += end - start
+
+numDiffs = len(op_list)
+print(f'number of differences = {numDiffs}')
+
+if numDiffs > 0:
+    # annotate the scores to show differences
+    start = timer()
+    sv.annotate_differences(score1, score2, op_list)
+    end = timer()
+    print('annotated the two music21 scores: {:.3f} seconds'.format(end - start))
+    totalTime += end - start
+
+    # display the two annotated scores
+    start = timer()
+    sv.show_differences(score1, score2)
+    end = timer()
+    print('rendered the two annotated scores: {:.3f} seconds'.format(end - start))
+    totalTime += end - start
+
+print('total time:: {:.3f} seconds'.format(totalTime))

--- a/compare.py
+++ b/compare.py
@@ -71,13 +71,6 @@ if badExt:
     printSupportedInputFormats()
     sys.exit(1)
 
-#print('stack limit =', resource.getrlimit(resource.RLIMIT_STACK))
-#print('recursion limit =', sys.getrecursionlimit())
-
-#sys.setrecursionlimit(1024*1024)
-
-#print('new stack limit =', resource.getrlimit(resource.RLIMIT_STACK))
-#print('new recursion limit =', sys.getrecursionlimit())
 totalTime = 0
 start = timer()
 score1 = m21.converter.parse(args.file1, forceSource=True)

--- a/lib/m21utils.py
+++ b/lib/m21utils.py
@@ -350,7 +350,9 @@ def note_to_string(note):
 
 
 def safe_get(list, idx):
-    if idx < len(list) and idx >= 0:
+    if list is None:
+        out = None
+    elif idx < len(list) and idx >= 0:
         out = list[idx]
     else:
         out = None


### PR DESCRIPTION
I have added a new compare.py script in the top-level folder, for easy comparison of any two score files that music21 can import.

python3 compare.py file1.musicxml file2.mei

Note that this pull request contains the safe_get(None, index) fix from pull request #3, so you could just take this one alone.