### PR TITLE
Don't call makeAccidentals() anymore.  I have realized now that this …

### DIFF
--- a/lib/NotationLinear.py
+++ b/lib/NotationLinear.py
@@ -231,10 +231,6 @@ class Bar:
         """
         :param measure: m21 measure
         """
-        # Have music21 run through the measure, marking whether or not each accidental will
-        # actually be displayed. We will use this info later, when comparing notation.
-        measure.makeAccidentals(inPlace=True, searchKeySignatureByContext=True)
-
         self.measure = measure.id
         self.voices_list = []
         if (


### PR DESCRIPTION
…was a workaround for a bug in my new humdrum importer.  music21 importers are required to do this work themselves (I didn't realize this before).  And my new humdrum importer now does it just fine.  So this extra call to makeAccidentals is at best a no-op, and at worst a source of unexpected differences during a compare operation.