### PR TITLE
Handle null metadata when putting 'score1' and 'score2' in composer n…

### DIFF
--- a/lib/score_comparison_lib.py
+++ b/lib/score_comparison_lib.py
@@ -721,7 +721,7 @@ def beamtuplet_leveinsthein_diff(original, compare_to, note1, note2, type):
             original, compare_to[1:], note1, note2, type
         )
         cost["ins" + type] += 1
-        op_list["ins" + type].append(("ins" + type, None, compare_to[0], 1))
+        op_list["ins" + type].append(("ins" + type, note1, note2, 1))
         # edit-pitch
         op_list["edit" + type], cost["edit" + type] = beamtuplet_leveinsthein_diff(
             original[1:], compare_to[1:], note1, note2, type

--- a/lib/score_visualization.py
+++ b/lib/score_visualization.py
@@ -618,20 +618,25 @@ def annotate_differences(score1, score2, operations):
 
 def show_differences(score1: m21.stream.Score, score2: m21.stream.Score):
     # display the two (annotated) scores
-    originalComposer1: str = score1.metadata.composer
+    originalComposer1: str = None
+    originalComposer2: str = None
+
+    if score1.metadata is None:
+        score1.metadata = m21.metadata.Metadata()
+    if score2.metadata is None:
+        score2.metadata = m21.metadata.Metadata()
+
+    originalComposer1 = score1.metadata.composer
     if originalComposer1 is None:
-        originalComposer1 = "score1"
+        score1.metadata.composer = "score1"
     else:
-        originalComposer1 = "score1          " + originalComposer1
+        score1.metadata.composer = "score1          " + originalComposer1
 
-    originalComposer2: str = score2.metadata.composer
+    originalComposer2 = score2.metadata.composer
     if originalComposer2 is None:
-        originalComposer2 = "score2"
+        score2.metadata.composer = "score2"
     else:
-        originalComposer2 = "score2          " + originalComposer2
-
-    score1.metadata.composer = originalComposer1
-    score2.metadata.composer = originalComposer2
+        score2.metadata.composer = "score2          " + originalComposer2
 
     score1.show('musicxml.pdf', makeNotation=False)
     score2.show('musicxml.pdf', makeNotation=False)


### PR DESCRIPTION
…ame. Fix comparison bug that was crashing when one score had more beams on a note than another.